### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/matrix2.yml
+++ b/.github/workflows/matrix2.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - '.github/workflows/matrix2.yml'
 
+permissions:
+  contents: read
+
 jobs:
   matrix_example:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/dbantawa22/github-action/security/code-scanning/2](https://github.com/dbantawa22/github-action/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function. Since the workflow only checks out the repository and runs tests, it likely only needs `contents: read` permissions. This ensures that the workflow cannot perform unintended write operations.

The `permissions` block will be added at the top level of the workflow, just below the `name` or `on` block, to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
