### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run_bashscript.yml
+++ b/.github/workflows/run_bashscript.yml
@@ -6,7 +6,9 @@ on:
       - main
     paths:
       - '.github/workflows/run_bashscript.yml'
-    
+
+permissions:
+  contents: read
 
 jobs:
   bashshell_job:


### PR DESCRIPTION
Potential fix for [https://github.com/dbantawa22/github-action/security/code-scanning/5](https://github.com/dbantawa22/github-action/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow only checks out code and runs bash scripts, it does not require write permissions. The minimal required permission is `contents: read`, which allows the workflow to read the repository contents. This change ensures the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
